### PR TITLE
rm jquery dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -30,7 +30,6 @@
     "index.html"
   ],
   "dependencies": {
-    "angular": "~1.2.14",
-    "jquery": "1"
+    "angular": "~1.2.14"
   }
 }


### PR DESCRIPTION
we shouldn't restrict jquery version; furthermore jqLite
(part of angular) includes everything we need.
