### PR TITLE
Event type change

### DIFF
--- a/ng-click-select.js
+++ b/ng-click-select.js
@@ -45,7 +45,7 @@
     return {
       restrict: 'AC',
       link: function (scope, element, attrs) {
-        element.bind('click', function () {
+        element.bind('focus', function () {
           this.select();
         });
       }


### PR DESCRIPTION
Hi, wouldn't using the `focus` event make more sense?
- it's triggered by both mouse & touch events
- it only selects the text… well, on focus. Meaning you can move the cursor around if you want to edit the input's text.

This would make the directives name slightly misleading but I don't think it's a big issue.
